### PR TITLE
change ikev2TransformTypes from array to object

### DIFF
--- a/bom-1.4-cbom-1.0.schema.json
+++ b/bom-1.4-cbom-1.0.schema.json
@@ -745,28 +745,27 @@
                   "description": "the TLS cipher suites supported, with naming convention according to IANA https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4"
                 },
                 "ikev2TransformTypes": {
-                  "type": "array",
+                  "type": "object",
                   "title": "IKEv2 transform types supported",
                   "description": "the IKEv2 transform types supported (types 1-4), according to RFC5996, section 3.3.2",
-                  "prefixItems": [
-                    {
+                  "properties": {
+                    "transformType1": {
                       "type": "array",
                       "title": "Transform Type 1: encryption algorithms"
                     },
-                    {
+                    "transformType2": {
                       "type": "array",
                       "title": "Transform Type 2: pseudorandom functions"
                     },
-                    {
+                    "transformType3": {
                       "type": "array",
                       "title": "Transform Type 3: integrity algorithms"
                     },
-                    {
+                    "transformType4": {
                       "type": "array",
                       "title": "Transform Type 4: DH groups"
                     }
-                  ],
-                  "items": false
+                  }
                 }
               }
             },


### PR DESCRIPTION
Change ikev2TransformTypes from array to object to be able to create a valid cbom which matches the json schema definition. With the current nested array definition, I could not create a valid cbom containing the ikev2TransformTypes.

**Validation**

1. Navigate to the following online [json schema validator](https://www.jsonschemavalidator.net/).
2. insert the current CBOM 1.0 schema
3. try to validate the following CBOM 

```json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4-cbom-1.0",
  "serialNumber": "urn:uuid:44371afa-c7cf-48cf-b385-17795344811a",
  "version": 1,
  "metadata": {},
  "components": [
    {
      "type": "crypto-asset",
      "bom-ref": "oid:1.3.18.0.2.32.104",
      "name": "tlsv12",
      "cryptoProperties": {
        "assetType": "protocol",
        "protocolProperties": {
          "tlsCipherSuites" : [
            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519)",
            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519)",
            "TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048)",
            "TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048)"
          ],
          "ikev2TransformTypes": [
            ["generic1ITT1"],
            ["generic1ITT2"]
          ]
        }
      }
    }
  ]
}
```

The validator will find two errors for the ikev2TransformTypes property.

Signed-off-by: Nicklas Körtge <nicklas.koertge1@ibm.com>